### PR TITLE
Change folder naming criteria

### DIFF
--- a/lib/collections/folder.js
+++ b/lib/collections/folder.js
@@ -107,9 +107,24 @@ module.exports = function(env) {
 			var name = env.toValidNameOrThrow(args.name);
 			var fields = env.toFieldStringOrThrow(args.fields);
 			
-			if(!/^[a-z0-9_-]{6,}$/i.test(name)) {
-				throw new Error('Malformed folder name sent to #folders.create');
+			//----------------------------------------------------------------------//
+			//--------------- format folder name for Box's acceptance --------------//
+			//----------------------------------------------------------------------//
+			// Box won't accept leading or trailing white space
+			// When a user manually names a folder with leading or trailing white space,
+			// 		Box automatically deletes it, so we will too
+			name = name.trim();
+
+			// Box won't allow folders to be named "." or ".."
+			if(name === "." || name === "..") {
+				throw new Error('Disallowed name sent to #folders.create');
 			}
+
+			// Box won't allow forward slashes or backslashes
+			// When a user manually names a folder with forward slashes or backslashes,
+			// 		Box automatically replaces them with underscores, so we will too
+			name = name.replace(/[\\\/]/g, "_");
+			//----------------------------------------------------------------------//
 
 			request.post(env.prepare({
 				url: util.format(


### PR DESCRIPTION
Folder name limitations will now match those imposed by box, and handling of disallowed characters (slashes, leading or trailing white space) and folder names ("." and "..") will now be handled exaclty how Box handles them.
