### PR TITLE
Explicitly added issued at time and not before time when creating JWT…

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,15 +93,18 @@ module.exports = function(args) {
     // #build(payload, claims, publicKey, privateKey, authKeys)
     //
 	return new Promise(function(resolve, reject) {
+		var now = Math.floor(Date.now() / 1000) - 5 // Now with a 5 second buffer
 		build({ 
 			box_sub_type: subjectType,
-			jti: 'this_is_reset_in_factory#set'
+			jti: 'this_is_reset_in_factory#set',
+			iat: now
 		}, { 
 			algorithm: algorithm,
 			issuer: issuer,
 			subject: subject,
 			audience: authEndpoint,
 			expiresIn: 58,
+			notBefore: -10,
 			headers: {
 				typ: 'JWT',
 				alg: algorithm,


### PR DESCRIPTION
Explicitly added issued at time and not before time when creating JWT token for box. These values also include small buffers to account for differences in box server time and local time.

This should fix an issue where multiple calls to the box api would have to be made to get a token.